### PR TITLE
Use Minitest 5

### DIFF
--- a/test/test_broken_graph.rb
+++ b/test/test_broken_graph.rb
@@ -3,10 +3,10 @@
 $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib") if __FILE__ == $0
 
 require 'transaction/simple'
-require 'test/unit'
+require 'minitest'
 
 module Transaction::Simple::Test
-  class BrokenGraph < Test::Unit::TestCase #:nodoc:
+  class BrokenGraph < Minitest::Test #:nodoc:
     class Child
       attr_accessor :parent
     end
@@ -41,7 +41,7 @@ module Transaction::Simple::Test
       parent << Child.new
       assert_equal(parent.object_id, parent.children[1].parent.object_id)
       parent.abort_transaction
-      assert_not_equal(parent.object_id, parent.children[0].parent.object_id)
+      refute_equal(parent.object_id, parent.children[0].parent.object_id)
     end
 
     def test_fixed_graph

--- a/test/test_transaction_simple.rb
+++ b/test/test_transaction_simple.rb
@@ -3,10 +3,10 @@
 $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib") if __FILE__ == $0
 
 require 'transaction/simple'
-require 'test/unit'
+require 'minitest'
 
 module Transaction::Simple::Test
-  class TransactionSimple < Test::Unit::TestCase #:nodoc:
+  class TransactionSimple < Minitest::Test #:nodoc:
     VALUE = "Now is the time for all good men to come to the aid of their country."
 
     class Value
@@ -38,18 +38,18 @@ module Transaction::Simple::Test
 
     def test_started
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
     end
 
     def test_rewind
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.rewind_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
-      assert_nothing_raised { @value.rewind_transaction }
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
+      @value.rewind_transaction
       assert_equal(true, @value.transaction_open?)
       assert_equal(VALUE, @value)
     end
@@ -57,11 +57,11 @@ module Transaction::Simple::Test
     def test_abort
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.abort_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
-      assert_nothing_raised { @value.abort_transaction }
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
+      @value.abort_transaction
       assert_equal(false, @value.transaction_open?)
       assert_equal(VALUE, @value)
     end
@@ -69,73 +69,67 @@ module Transaction::Simple::Test
     def test_commit
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.commit_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.commit_transaction }
+      @value.commit_transaction
       assert_equal(false, @value.transaction_open?)
-      assert_not_equal(VALUE, @value)
+      refute_equal(VALUE, @value)
     end
 
     def test_multilevel
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
+      @value.gsub!(/men/, 'women')
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
-      assert_nothing_raised { @value.gsub!(/country/, 'nation-state') }
-      assert_nothing_raised { @value.commit_transaction }
+      @value.start_transaction
+      @value.gsub!(/country/, 'nation-state')
+      @value.commit_transaction
       assert_equal(VALUE.gsub(/men/, 'women').gsub(/country/, 'nation-state'), @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.abort_transaction }
+      @value.abort_transaction
       assert_equal(VALUE, @value)
     end
 
     def test_multilevel_named
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.transaction_name }
-      assert_nothing_raised { @value.start_transaction(:first) } # 1
+      @value.start_transaction(:first)
       assert_raises(Transaction::TransactionError) { @value.start_transaction(:first) }
       assert_equal(true, @value.transaction_open?)
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(:first, @value.transaction_name)
-      assert_nothing_raised { @value.start_transaction } # 2
-      assert_not_equal(:first, @value.transaction_name)
+      @value.start_transaction
+      refute_equal(:first, @value.transaction_name)
       assert_equal(nil, @value.transaction_name)
       assert_raises(Transaction::TransactionError) { @value.abort_transaction(:second) }
-      assert_nothing_raised { @value.abort_transaction(:first) }
+      @value.abort_transaction(:first)
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised do
-        @value.start_transaction(:first)
-        @value.gsub!(/men/, 'women')
-        @value.start_transaction(:second)
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
-      assert_nothing_raised { @value.abort_transaction(:second) }
+      @value.start_transaction(:first)
+      @value.gsub!(/men/, 'women')
+      @value.start_transaction(:second)
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
+      @value.abort_transaction(:second)
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised do
-        @value.start_transaction(:second)
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
+      @value.start_transaction(:second)
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
       assert_raises(Transaction::TransactionError) { @value.rewind_transaction(:foo) }
-      assert_nothing_raised { @value.rewind_transaction(:second) }
+      @value.rewind_transaction(:second)
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised do
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
       assert_raises(Transaction::TransactionError) { @value.commit_transaction(:foo) }
-      assert_nothing_raised { @value.commit_transaction(:first) }
+      @value.commit_transaction(:first)
       assert_equal(VALUE.gsub(/men/, 'sentients'), @value)
       assert_equal(false, @value.transaction_open?)
     end
@@ -143,7 +137,7 @@ module Transaction::Simple::Test
     def test_block
       Transaction::Simple.start(@value) do |tv|
         assert_equal(true, tv.transaction_open?)
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         tv.abort_transaction
         flunk("Failed to abort the transaction.")
@@ -154,7 +148,7 @@ module Transaction::Simple::Test
       @value = VALUE.dup
       Transaction::Simple.start(@value) do |tv|
         assert_equal(true, tv.transaction_open?)
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         tv.commit_transaction
         flunk("Failed to commit the transaction.")
@@ -167,7 +161,7 @@ module Transaction::Simple::Test
       Transaction::Simple.start_named(:first, @value) do |tv|
         assert_equal(true, tv.transaction_open?)
         assert_equal(true, tv.transaction_open?(:first))
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         tv.abort_transaction
         flunk("Failed to abort the transaction.")
@@ -180,7 +174,7 @@ module Transaction::Simple::Test
       Transaction::Simple.start_named(:first, @value) do |tv|
         assert_equal(true, tv.transaction_open?)
         assert_equal(true, tv.transaction_open?(:first))
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         tv.commit_transaction
         flunk("Failed to commit the transaction.")
@@ -196,7 +190,7 @@ module Transaction::Simple::Test
         assert_equal(true, tv.transaction_open?)
         assert_equal(true, tv.transaction_open?(:first))
         assert_equal(true, tv.transaction_open?(:second))
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         assert_raises(Transaction::TransactionError) do
           tv.abort_transaction(:first)
@@ -206,7 +200,7 @@ module Transaction::Simple::Test
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(false, @value.transaction_open?(:second))
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised { @value.abort_transaction(:first) }
+      @value.abort_transaction(:first)
       assert_equal(VALUE, @value)
 
       @value.start_transaction(:first)
@@ -214,7 +208,7 @@ module Transaction::Simple::Test
         assert_equal(true, tv.transaction_open?)
         assert_equal(true, tv.transaction_open?(:first))
         assert_equal(true, tv.transaction_open?(:second))
-        assert_nothing_raised { tv.gsub!(/men/, 'women') }
+        tv.gsub!(/men/, 'women')
         assert_equal(VALUE.gsub(/men/, 'women'), tv)
         assert_raises(Transaction::TransactionError) do
           tv.commit_transaction(:first)
@@ -224,7 +218,7 @@ module Transaction::Simple::Test
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(false, @value.transaction_open?(:second))
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised { @value.abort_transaction(:first) }
+      @value.abort_transaction(:first)
       assert_equal(VALUE, @value)
     end
 
@@ -272,17 +266,15 @@ module Transaction::Simple::Test
     end
 
     def test_array
-      assert_nothing_raised do
-        @orig = ["first", "second", "third"]
-        @value = ["first", "second", "third"]
-        @value.extend(Transaction::Simple)
-      end
+      @orig = ["first", "second", "third"]
+      @value = ["first", "second", "third"]
+      @value.extend(Transaction::Simple)
       assert_equal(@orig, @value)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value[1].gsub!(/second/, "fourth") }
-      assert_not_equal(@orig, @value)
-      assert_nothing_raised { @value.abort_transaction }
+      @value[1].gsub!(/second/, "fourth")
+      refute_equal(@orig, @value)
+      @value.abort_transaction
       assert_equal(@orig, @value)
     end
 

--- a/test/test_transaction_simple_group.rb
+++ b/test/test_transaction_simple_group.rb
@@ -3,10 +3,10 @@
 $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib") if __FILE__ == $0
 
 require 'transaction/simple/group'
-require 'test/unit'
+require 'minitest'
 
 module Transaction::Simple::Test
-  class Group < Test::Unit::TestCase #:nodoc:
+  class Group < Minitest::Test #:nodoc:
     VALUE1  = "Hello, you."
     VALUE2  = "And you, too."
 
@@ -18,7 +18,7 @@ module Transaction::Simple::Test
     def test_group
       group = Transaction::Simple::Group.new(@x, @y)
 
-      assert_nothing_raised { group.start_transaction(:first) }
+      group.start_transaction(:first)
       assert_equal(true, group.transaction_open?(:first))
       assert_equal(true, @x.transaction_open?(:first))
       assert_equal(true, @y.transaction_open?(:first))
@@ -26,22 +26,22 @@ module Transaction::Simple::Test
       assert_equal("Hello, world.", @x.gsub!(/you/, "world"))
       assert_equal("And me, too.", @y.gsub!(/you/, "me"))
 
-      assert_nothing_raised { group.start_transaction(:second) }
+      group.start_transaction(:second)
       assert_equal("Hello, HAL.", @x.gsub!(/world/, "HAL"))
       assert_equal("And Dave, too.", @y.gsub!(/me/, "Dave"))
 
-      assert_nothing_raised { group.rewind_transaction(:second) }
+      group.rewind_transaction(:second)
       assert_equal("Hello, world.", @x)
       assert_equal("And me, too.", @y)
 
       assert_equal("Hello, HAL.", @x.gsub!(/world/, "HAL"))
       assert_equal("And Dave, too.", @y.gsub!(/me/, "Dave"))
 
-      assert_nothing_raised { group.commit_transaction(:second) }
+      group.commit_transaction(:second)
       assert_equal("Hello, HAL.", @x)
       assert_equal("And Dave, too.", @y)
 
-      assert_nothing_raised { group.abort_transaction(:first) }
+      group.abort_transaction(:first)
       assert_equal("Hello, you.", @x)
       assert_equal("And you, too.", @y)
     end

--- a/test/test_transaction_simple_threadsafe.rb
+++ b/test/test_transaction_simple_threadsafe.rb
@@ -3,10 +3,10 @@
 $LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib") if __FILE__ == $0
 
 require 'transaction/simple/threadsafe'
-require 'test/unit'
+require 'minitest'
 
 module Transaction::Simple::Test
-  class ThreadSafe < Test::Unit::TestCase #:nodoc:
+  class ThreadSafe < Minitest::Test #:nodoc:
     VALUE = "Now is the time for all good men to come to the aid of their country."
 
     def setup
@@ -20,18 +20,18 @@ module Transaction::Simple::Test
 
     def test_started
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
     end
 
     def test_rewind
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.rewind_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
-      assert_nothing_raised { @value.rewind_transaction }
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
+      @value.rewind_transaction
       assert_equal(true, @value.transaction_open?)
       assert_equal(VALUE, @value)
     end
@@ -39,11 +39,11 @@ module Transaction::Simple::Test
     def test_abort
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.abort_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
-      assert_nothing_raised { @value.abort_transaction }
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
+      @value.abort_transaction
       assert_equal(false, @value.transaction_open?)
       assert_equal(VALUE, @value)
     end
@@ -51,89 +51,81 @@ module Transaction::Simple::Test
     def test_commit
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.commit_transaction }
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
-      assert_not_equal(VALUE, @value)
+      @value.gsub!(/men/, 'women')
+      refute_equal(VALUE, @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.commit_transaction }
+      @value.commit_transaction
       assert_equal(false, @value.transaction_open?)
-      assert_not_equal(VALUE, @value)
+      refute_equal(VALUE, @value)
     end
 
     def test_multilevel
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.gsub!(/men/, 'women') }
+      @value.gsub!(/men/, 'women')
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.start_transaction }
-      assert_nothing_raised { @value.gsub!(/country/, 'nation-state') }
-      assert_nothing_raised { @value.commit_transaction }
+      @value.start_transaction
+      @value.gsub!(/country/, 'nation-state')
+      @value.commit_transaction
       assert_equal(VALUE.gsub(/men/, 'women').gsub(/country/, 'nation-state'), @value)
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value.abort_transaction }
+      @value.abort_transaction
       assert_equal(VALUE, @value)
     end
 
     def test_multilevel_named
       assert_equal(false, @value.transaction_open?)
       assert_raises(Transaction::TransactionError) { @value.transaction_name }
-      assert_nothing_raised { @value.start_transaction(:first) } # 1
+      @value.start_transaction(:first)
       assert_raises(Transaction::TransactionError) { @value.start_transaction(:first) }
       assert_equal(true, @value.transaction_open?)
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(:first, @value.transaction_name)
-      assert_nothing_raised { @value.start_transaction } # 2
-      assert_not_equal(:first, @value.transaction_name)
+      @value.start_transaction
+      refute_equal(:first, @value.transaction_name)
       assert_equal(nil, @value.transaction_name)
       assert_raises(Transaction::TransactionError) { @value.abort_transaction(:second) }
-      assert_nothing_raised { @value.abort_transaction(:first) }
+      @value.abort_transaction(:first)
       assert_equal(false, @value.transaction_open?)
-      assert_nothing_raised do
-        @value.start_transaction(:first)
-        @value.gsub!(/men/, 'women')
-        @value.start_transaction(:second)
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
-      assert_nothing_raised { @value.abort_transaction(:second) }
+      @value.start_transaction(:first)
+      @value.gsub!(/men/, 'women')
+      @value.start_transaction(:second)
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
+      @value.abort_transaction(:second)
       assert_equal(true, @value.transaction_open?(:first))
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised do
-        @value.start_transaction(:second)
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
+      @value.start_transaction(:second)
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
       assert_raises(Transaction::TransactionError) { @value.rewind_transaction(:foo) }
-      assert_nothing_raised { @value.rewind_transaction(:second) }
+      @value.rewind_transaction(:second)
       assert_equal(VALUE.gsub(/men/, 'women'), @value)
-      assert_nothing_raised do
-        @value.gsub!(/women/, 'people')
-        @value.start_transaction
-        @value.gsub!(/people/, 'sentients')
-      end
+      @value.gsub!(/women/, 'people')
+      @value.start_transaction
+      @value.gsub!(/people/, 'sentients')
       assert_raises(Transaction::TransactionError) { @value.commit_transaction(:foo) }
-      assert_nothing_raised { @value.commit_transaction(:first) }
+      @value.commit_transaction(:first)
       assert_equal(VALUE.gsub(/men/, 'sentients'), @value)
       assert_equal(false, @value.transaction_open?)
     end
 
     def test_array
-      assert_nothing_raised do
-        @orig = ["first", "second", "third"]
-        @value = ["first", "second", "third"]
-        @value.extend(Transaction::Simple::ThreadSafe)
-      end
+      @orig = ["first", "second", "third"]
+      @value = ["first", "second", "third"]
+      @value.extend(Transaction::Simple::ThreadSafe)
       assert_equal(@orig, @value)
-      assert_nothing_raised { @value.start_transaction }
+      @value.start_transaction
       assert_equal(true, @value.transaction_open?)
-      assert_nothing_raised { @value[1].gsub!(/second/, "fourth") }
-      assert_not_equal(@orig, @value)
-      assert_nothing_raised { @value.abort_transaction }
+      @value[1].gsub!(/second/, "fourth")
+      refute_equal(@orig, @value)
+      @value.abort_transaction
       assert_equal(@orig, @value)
     end
   end


### PR DESCRIPTION
Since Ruby won't include test/unit anymore in stdlib I suppose it's a good time to move on Minitest 5. I created this patch as we are already running on Minitest 5 because of Rails 4.1.
